### PR TITLE
Add support for \N{IDEOGRAPHIC ITERATION MARK}

### DIFF
--- a/lib/Lingua/JA/Name/Splitter.pm
+++ b/lib/Lingua/JA/Name/Splitter.pm
@@ -37,22 +37,22 @@ sub split_kanji_name
     my ($kanji) = @_;
     # Validate the user's input
     if (! $kanji) {
-	carp "No valid name was provided to split_kanji_name";
-	return undef;
+        carp "No valid name was provided to split_kanji_name";
+        return undef;
     }
     if (length $kanji == 1) {
-	carp "$kanji is only one character long, so there is nothing to split";
-	return ($kanji, '');
+        carp "$kanji is only one character long, so there is nothing to split";
+        return ($kanji, '');
     }
-    if ($kanji !~ /^(\p{InCJKUnifiedIdeographs}|\p{InKana})+$/) {
-	carp "$kanji does not look like a kanji/kana name";
+    if ($kanji !~ /^(\p{InCJKUnifiedIdeographs}|々|\p{InKana})+$/) {
+        carp "$kanji does not look like a kanji/kana name";
     }
     if (! wantarray ()) {
         carp "The return value of split_kanji_name is an array";
     }
     # If the name is only two characters, there is only one possibility.
     if (length $kanji == 2) {
-	return split '', $kanji;
+        return split '', $kanji;
     }
 
     # What we guess is the given name part of the name
@@ -80,6 +80,10 @@ sub split_kanji_name
         elsif ($known{$moji}) {
             $p = $length_weight * $p + (1 - $length_weight) * $known{$moji};
         }
+        elsif ($moji eq '々') {
+            # This repeated kanji has the same probability as the original kanji
+            $p = $probability[$i - 1];
+        }
         $probability[$i] = $p;
     }
 #    print "@probability\n";
@@ -103,8 +107,8 @@ sub split_romaji_name
 {
     my ($name) = @_;
     if (! $name) {
-	carp "No name given to split_romaji_name";
-	return undef;
+        carp "No name given to split_romaji_name";
+        return undef;
     }
     if (! wantarray ()) {
         carp "The return value of split_romaji_name is an array";
@@ -129,11 +133,11 @@ sub split_romaji_name
         # Remove leading and trailing spaces.
         $name =~ s/^\s+|\s+$//g;
         my @parts = split /,?\s+/, $name;
-	for (@parts) {
-	    if (! is_romaji_strict ($_)) {
-		carp "'$_' doesn't look like Japanese romaji";
-	    }
-	}
+        for (@parts) {
+            if (! is_romaji_strict ($_)) {
+                carp "'$_' doesn't look like Japanese romaji";
+            }
+        }
         # If there are more than two parts to the name after splitting by spaces
         if (@parts > 2) {
             carp "Strange Japanese name '$name' with middle name?";

--- a/t/Lingua-JA-Name-Splitter.t
+++ b/t/Lingua-JA-Name-Splitter.t
@@ -1,9 +1,11 @@
 use warnings;
 use strict;
-use Test::More;# tests;# => 3;
+use Test::More;# tests;# => 20;
+use Test::Warnings;
 BEGIN { use_ok('Lingua::JA::Name::Splitter') };
 use Lingua::JA::Name::Splitter qw/split_kanji_name split_romaji_name/;
 use utf8;
+use open qw(:std :encoding(UTF-8)); # For warnings
 
 my $builder = Test::More->builder;
 binmode $builder->output,         ":utf8";
@@ -21,6 +23,7 @@ my %names = (
     団令子 => 1,
     風太郎 => 1,
     杉浦則夫 => 2,
+    佐々木順平 => 3
 );
 
 for my $name (keys %names) {


### PR DESCRIPTION
Hi, The name "佐々木順平" resulted in a warning because the ideographic iteration mark (々) isn't InCJKUnifiedIdeographs. It's InCJK_Symbols. It's a symbol that repeats the previous kanji.

This patch adds support for it by preventing the "does not look like a kanji/kana name" warning when it appears.

It also copies the probability of the previous kanji as the probability for the iteration mark. It mostly works without this change, but I can imagine cases where it wouldn't work without it.

It also changes a few stray tab characters to space indenting for consistency.

In the test file, I added `use Test::Warnings` and `use open qw(:std :encoding(UTF-8))` to first see the warning before changing the module to remove the warning.