### PR TITLE
Make split_kanji_name faster, and 100% coverage

### DIFF
--- a/lib/Lingua/JA/Name/Splitter.pm
+++ b/lib/Lingua/JA/Name/Splitter.pm
@@ -35,7 +35,8 @@ our $split_cutoff = 0.5;
 
 # Set this to a true value to print debugging messages.
 
-my $debug;
+#my $debug = 1;
+#use open qw(:std :encoding(UTF-8));a # when debugging
 
 =head2 $kkre
 
@@ -82,10 +83,6 @@ sub split_kanji_name
 	return split '', $kanji;
     }
 
-    # What we guess is the given name part of the name
-    my $given;
-    # What we guess is the family name part of the name
-    my $family;
     # The characters in the name, which may not be kanji.
     my @kanji = split '', $kanji;
     # Probability this character is part of the family name.
@@ -113,24 +110,14 @@ sub split_kanji_name
             $p = $probability[$i - 1];
         }
         $probability[$i] = $p;
-    }
-    if ($debug) {
-	print "@probability\n";
-	print "@kanji\n";
-    }
-    my $in_given;
-    for my $i (0..$#kanji) {
+        #if ($debug) { # Commented out to improve test coverage
+        #    print STDERR "$kanji[$i] i=$i p=$p\n";
+        #}
         if ($probability[$i] < $split_cutoff) {
-            $in_given = 1;
-        }
-        if ($in_given) {
-            $given .= $kanji[$i];
-        }
-        else {
-            $family .= $kanji[$i];
+            return (substr ($kanji, 0, $i), substr ($kanji, $i));
         }
     }
-    return ($family, $given);
+    return (substr ($kanji, 0, -1), substr ($kanji, -1));
 }
 
 sub split_romaji_name

--- a/t/Lingua-JA-Name-Splitter.t
+++ b/t/Lingua-JA-Name-Splitter.t
@@ -1,6 +1,8 @@
 use warnings;
 use strict;
-use Test::More;# tests;# => 3;
+use Test::More;# tests => 38;
+use Test::Deep;
+use Test::Warnings ':all';
 BEGIN { use_ok('Lingua::JA::Name::Splitter') };
 use Lingua::JA::Name::Splitter qw/split_kanji_name split_romaji_name/;
 use utf8;
@@ -14,6 +16,8 @@ binmode $builder->todo_output,    ":utf8";
 # mode: perl
 # End:
 
+# Test split_kanji_name()
+
 my %names = (
     鈴木太郎 => 2,
     福田雅樹 => 2,
@@ -22,6 +26,8 @@ my %names = (
     風太郎 => 1,
     杉浦則夫 => 2,
     佐々木順平 => 3,
+    佐じ => 1, # Trivially short (for coverage)
+    佐张ケイ => 2, # Includes "unknown" kanji (for coverage)
 );
 
 for my $name (keys %names) {
@@ -31,15 +37,46 @@ for my $name (keys %names) {
         "Right name lengths");
 }
 
-my $name1 = 'KATSU, Shintaro';
-my $name2 = 'Risa Yoshiki';
+my @warnings = warnings { my @tmp = split_kanji_name () };
+cmp_deeply ([@warnings], [re (qr/No valid name was provided to split_kanji_name/)], 'kanji name not supplied warning');
 
-my ($first1, $last1) = split_romaji_name ($name1);
-ok ($first1 eq 'Shintaro', "Split $name1 -> $first1 OK");
-ok ($last1 eq 'Katsu', "Split $name1 -> $last1 OK");
+@warnings = warnings { my @tmp = split_kanji_name ('佐') };
+cmp_deeply ([@warnings], [re (qr/is only one character long, so there is nothing to split/)], 'kanji name too short warning');
 
-my ($first2, $last2) = split_romaji_name ($name2);
-ok ($first2 eq 'Risa', "Split $name2 -> $first2 OK");
-ok ($last2 eq 'Yoshiki', "Split $name2 -> $last2 OK");
+@warnings = warnings { my @tmp = split_kanji_name ('abc') };
+cmp_deeply ([@warnings], [re (qr/does not look like a kanji\/kana name/)], 'kanji name not kanji/kana warning');
+
+@warnings = warnings { my $tmp = split_kanji_name ('鈴木太郎') };
+cmp_deeply ([@warnings], [re (qr/The return value of split_kanji_name is an array/)], 'kanji not array context warning');
+
+# Test split_romaji_name()
+
+my @romaji_names = (
+    ['KATSU, Shintaro', 'Shintaro', 'Katsu'],
+    ['Katsu, Shintaro', 'Shintaro', 'Katsu'],
+    ['Risa Yoshiki', 'Risa', 'Yoshiki'],
+    ['RisaYOSHIKI', 'Risa', 'Yoshiki'],
+    ['Yoshiki', '', 'Yoshiki'],
+);
+
+for my $case (@romaji_names)
+{
+    my ($name, $first, $last) = @{$case};
+    my ($first1, $last1) = split_romaji_name ($name);
+    is ($first1, $first, "Split $name -> first $first1");
+    is ($last1, $last, "Split $name -> last $last1");
+}
+
+@warnings = warnings { my @tmp = split_romaji_name () };
+cmp_deeply ([@warnings], [re (qr/No name given to split_romaji_name/)], 'romaji name not supplied warning');
+
+@warnings = warnings { my $tmp = split_romaji_name ('Risa Yoshiki') };
+cmp_deeply ([@warnings], [re (qr/The return value of split_romaji_name is an array/)], 'romaji not array context warning');
+
+@warnings = warnings { my @tmp = split_romaji_name ('Risa XYZ') };
+cmp_deeply ([@warnings], [re (qr/doesn't look like Japanese romaji/)], 'romaji name not romaji warning');
+
+@warnings = warnings { my @tmp = split_romaji_name ('Risa Shintaro Katsu') };
+cmp_deeply ([@warnings], [re (qr/Strange Japanese name '.*' with middle name\?/)], 'romaji middle name warning');
 
 done_testing ();


### PR DESCRIPTION
This pull request makes `split_kanji_name()` faster by eliminating the second loop, and terminating the first loop as soon as the probability drops below the 0.5 cutoff, and returning the given and family names immediately.

This change might also fix a potential/theoretical bug whereby known kanji with a high probability of being in a family name actually appears in the given name and could be appended to the family name, although this might never happen, and even if it does, its position might reduce the probability enough that it wouldn't end up in the family name. But this way, there's no chance of that happening.

This pull request also adds some tests to increase the test coverage from 74.4% to 100%.